### PR TITLE
Stop using thread-local storage for overrides

### DIFF
--- a/lib/experimental.rb
+++ b/lib/experimental.rb
@@ -46,10 +46,10 @@ module Experimental
       self.experiment_data = nil
       Experiment.reset_population_filters
     end
-  end
 
-  def self.overrides
-    Thread.current[:experimental_overrides] ||= Overrides.new
+    def overrides
+      @experimental_overrides ||= Overrides.new
+    end
   end
 end
 

--- a/spec/lib/experimental_spec.rb
+++ b/spec/lib/experimental_spec.rb
@@ -28,4 +28,13 @@ describe Experimental do
       end.join
     end
   end
+
+  describe ".overrides" do
+    it "ensures the overrides state persists across threads (e.g. capybara threads)" do
+      override = Experimental.overrides
+      Thread.new do
+        Experimental.overrides.should eq(override)
+      end.join
+    end
+  end
 end


### PR DESCRIPTION
- They don't persist properly in capybara/js tests since capybara
  spawns new threads. This keeps the overrides shared.
