### PR TITLE
Ensure experiments are started when overriding in specs

### DIFF
--- a/lib/experimental/test.rb
+++ b/lib/experimental/test.rb
@@ -32,6 +32,11 @@ module Experimental
     #
     # If +bucket+ is nil, exclude the user from the experiment.
     def set_experimental_bucket(subject, experiment_name, bucket)
+      # Make sure the experiment is started
+      Experimental.source[experiment_name].try do |e|
+        e.update(start_date: Time.now) unless e.started?
+      end
+
       Experimental.overrides[subject, experiment_name] = bucket
     end
 


### PR DESCRIPTION
Tested this and it fixes all the breakages caused by previous PR.

I think it should be fine, since if you're overriding the experiment with `set_experimental_bucket` you're likely expecting the experiment to be started.