### PR TITLE
adds support for checking if a user is in `n` buckets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Gemfile.lock
 spec/dummy-rails*/log
 *~
+.idea/

--- a/lib/experimental/subject.rb
+++ b/lib/experimental/subject.rb
@@ -12,8 +12,8 @@ module Experimental
       Experimental.source[name].try { |e| e.in?(self) ? e.bucket(self) : nil }
     end
 
-    def in_bucket?(name, bucket)
-      in_experiment?(name) && experiment_bucket(name) == bucket
+    def in_bucket?(name, bucket, *args)
+      in_experiment?(name) && experiment_bucket(name).in?(args << bucket)
     end
 
     def experiment_seed_value

--- a/spec/models/experimental/subject_spec.rb
+++ b/spec/models/experimental/subject_spec.rb
@@ -118,6 +118,7 @@ describe Experimental::Subject do
         end
       end
     end
+
     context "user is not in experiment" do
       include_context "not in experiment"
       before do
@@ -132,6 +133,26 @@ describe Experimental::Subject do
       context "not given the user's experiment bucket" do
         it "returns false" do
           user.in_bucket?(experiment_name, 1).should be_falsey
+        end
+      end
+    end
+
+    context "user is in multiple buckets" do
+      let(:buckets) { [0, 1, 2] }
+
+      context "given the user's experiment bucket" do
+        include_context "in experiment bucket 0"
+
+        it "returns true" do
+          user.in_bucket?(experiment_name, *buckets).should be_truthy
+        end
+      end
+
+      context "given the user's experiment bucket" do
+        include_context "in experiment bucket 1"
+
+        it "returns true" do
+          user.in_bucket?(experiment_name, *buckets).should be_truthy
         end
       end
     end


### PR DESCRIPTION
I decided to use `args << bucket` to ensure there is at least 1 bucket passed which seems slightly better than manually raising in the method body `if args.empty?`